### PR TITLE
Use default mainSolution. 

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -52,7 +52,7 @@ export function pathToStatic() {
  * @param path Problem path
  */
 export function mainSolution(path: string): string {
-    let config = ConfigFile.loadConfig(path);
+    let config = ConfigFile.loadConfig(path).unwrapOr(ConfigFile.empty());
     if (config.mainSolution.isNone()) {
         config.mainSolution = Option.some(populateMainSolution(path, false));
     }
@@ -276,11 +276,7 @@ export function newArena(path: string) {
     let attic = join(path, ATTIC);
     createFolder(attic);
 
-    let config = ConfigFile.empty();
-    try {
-        // Try to load current config file if it exists.
-        config = ConfigFile.loadConfig(path);
-    } catch (err) {}
+    let config = ConfigFile.loadConfig(path, true).unwrapOr(ConfigFile.empty());
 
     if (config.mainSolution.isNone()) {
         config.mainSolution = Option.some(populateMainSolution(path, true));
@@ -341,7 +337,7 @@ function addChecker(path: string, config: ConfigFile) {
 }
 
 export function upgradeArena(path: string) {
-    let config = ConfigFile.loadConfig(path);
+    let config = ConfigFile.loadConfig(path).unwrapOr(ConfigFile.empty());
 
     // Load brute force solution
     if (
@@ -562,7 +558,7 @@ export function timedRun(
  * @param path
  */
 export function testSolution(path: string): Option<SolutionResult> {
-    let config = ConfigFile.loadConfig(path);
+    let config = ConfigFile.loadConfig(path, true).unwrap();
 
     // Load main solution (compile if necessary)
     let mainSolution_ = getMainSolutionPath(path, config);
@@ -815,7 +811,7 @@ export function stressSolution(
     path: string,
     times: number
 ): Option<SolutionResult> {
-    let config = ConfigFile.loadConfig(path);
+    let config = ConfigFile.loadConfig(path, true).unwrap();
 
     // Load main solution (compile if necessary)
     let mainSolution_ = getMainSolutionPath(path, config);

--- a/src/core.ts
+++ b/src/core.ts
@@ -673,7 +673,9 @@ function getMainSolutionPath(
     config: ConfigFile
 ): Option<CompileResult> {
     if (config.mainSolution.isNone()) {
-        vscode.window.showErrorMessage("Open a coding environment.");
+        vscode.window.showErrorMessage(
+            "Set main solution or open a coding environment."
+        );
         return Option.none();
     }
 
@@ -681,7 +683,9 @@ function getMainSolutionPath(
     let mainSolutionOutput = join(path, ATTIC, "sol");
 
     if (!existsSync(mainSolution)) {
-        vscode.window.showErrorMessage("Open a coding environment.");
+        vscode.window.showErrorMessage(
+            `Main solution ${mainSolution} doesn't exists. Open a coding environment.`
+        );
         return Option.none();
     }
 

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -310,6 +310,14 @@ export class ConfigFile {
     }
 
     static loadConfig(path: string): ConfigFile {
+        let configPath = join(path, ATTIC, "config.json");
+
+        if (!existsSync(configPath)) {
+            let config = ConfigFile.empty();
+            config.mainSolution = Option.some(join(path, "sol.cpp"));
+            return config;
+        }
+
         let configData = readFileSync(join(path, ATTIC, "config.json"), "utf8");
         let parsed = JSON.parse(configData);
 

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -275,6 +275,21 @@ export class ConfigFile {
         this.checker = new Option(checker);
     }
 
+    /**
+     * Check configuration file already exist, and create it otherwise with
+     * default solution problem.
+     */
+    static checkExist(path: string) {
+        if (!existsSync(join(path, ATTIC, "config.json"))) {
+            let config = ConfigFile.empty();
+            let mainSolution = join(path, "sol.cpp");
+            if (existsSync(mainSolution)) {
+                config.mainSolution = Option.some(mainSolution);
+            }
+            config.dump(path);
+        }
+    }
+
     dump(path: string) {
         let configFile = JSON.stringify(this, null, 2);
         writeToFileSync(join(path, ATTIC, "config.json"), configFile);
@@ -309,30 +324,38 @@ export class ConfigFile {
         return changed;
     }
 
-    static loadConfig(path: string): ConfigFile {
+    static loadConfig(
+        path: string,
+        checkExist: boolean = false
+    ): Option<ConfigFile> {
+        if (checkExist) {
+            ConfigFile.checkExist(path);
+        }
+
         let configPath = join(path, ATTIC, "config.json");
 
-        if (!existsSync(configPath)) {
-            let config = ConfigFile.empty();
-            config.mainSolution = Option.some(join(path, "sol.cpp"));
-            return config;
+        if (existsSync(configPath)) {
+            let configData = readFileSync(
+                join(path, ATTIC, "config.json"),
+                "utf8"
+            );
+            let parsed = JSON.parse(configData);
+
+            let config = new ConfigFile(
+                parsed.mainSolution?.value,
+                parsed.bruteSolution?.value,
+                parsed.generator?.value,
+                parsed.checker?.value
+            );
+
+            if (config.verify()) {
+                config.dump(path);
+            }
+
+            return Option.some(config);
+        } else {
+            return Option.none();
         }
-
-        let configData = readFileSync(join(path, ATTIC, "config.json"), "utf8");
-        let parsed = JSON.parse(configData);
-
-        let config = new ConfigFile(
-            parsed.mainSolution?.value,
-            parsed.bruteSolution?.value,
-            parsed.generator?.value,
-            parsed.checker?.value
-        );
-
-        if (config.verify()) {
-            config.dump(path);
-        }
-
-        return config;
     }
 
     static empty(): ConfigFile {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,12 @@ export function substituteArgWith(
         arg = arg.replace("$HOME", process.env["HOME"]);
     }
 
+    // Windows equivalent for unix $HOME. Note that if $HOME environment variable exist
+    // it will be used instead of USERPROFILE.
+    if (process.env["USERPROFILE"] !== undefined) {
+        arg = arg.replace("$HOME", process.env["USERPROFILE"]);
+    }
+
     return arg;
 }
 


### PR DESCRIPTION
Use sol.cpp as mainSolution when no config.json is present.
This way it will allow run old problems with new settings.

Fix #67
Fix #66 