### PR TITLE
Added oj instead of cf-submit

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,8 +500,8 @@ async function copySubmissionToClipboard() {
     let submissionCommand:
         | string
         | undefined = vscode.workspace
-        .getConfiguration("acmx.configuration", null)
-        .get("copyToClipboardCommand");
+            .getConfiguration("acmx.configuration", null)
+            .get("copyToClipboardCommand");
     let sol = mainSolution(path);
     let content = "";
 
@@ -555,7 +555,7 @@ async function submitSolution() {
         return;
     }
 
-    let cfcommand = `cf submit -f "${mainSolutionPath}" "${url_.unwrap()}"`;
+    let cfcommand = `oj submit "${url_.unwrap()}" "${mainSolutionPath}"`;
     debug("submit-solution-command", `${cfcommand}`);
 
     await vscode.window.activeTextEditor?.document.save().then(() => {
@@ -680,4 +680,4 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -500,8 +500,8 @@ async function copySubmissionToClipboard() {
     let submissionCommand:
         | string
         | undefined = vscode.workspace
-            .getConfiguration("acmx.configuration", null)
-            .get("copyToClipboardCommand");
+        .getConfiguration("acmx.configuration", null)
+        .get("copyToClipboardCommand");
     let sol = mainSolution(path);
     let content = "";
 
@@ -680,4 +680,4 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {}


### PR DESCRIPTION
Adds oj command to submit: https://github.com/online-judge-tools/oj

Install it using `pip3 install online-judge-tools`

First login using `oj login URL`. Example: `oj login https://codeforces.com/`

Supported judges for submission are 

- AtCoder
- Codeforces
- Topcoder (Marathon Match)
- yukicoder
- HackerRank
- Toph (Problem Archive)